### PR TITLE
Use idiomatic assertion protocol

### DIFF
--- a/Environment/Environment.tex
+++ b/Environment/Environment.tex
@@ -1328,11 +1328,11 @@ When we run this method, the execution of the \ct{self halt} will bring up the \
 
 That's all there is to the debugger, but it's not all there is to the \ct{suffix} method.  
 The initial bug should have made you realize that if there is no dot in the target string, the \ct{suffix} method will raise an error.  
-This isn't the behaviour that we want, so let's add a second test to specify what should happen in this case.
+This isn't the behavior that we want, so let's add a second test to specify what should happen in this case.
 
 \begin{method}[testNoSuffix]{A second test for the \ct{suffix} method: the target has no suffix}
 testSuffixNotFound
-	self assert: 'readme' suffix = ''
+	self assert: '' equals: 'readme' suffix.
 \end{method}
 
 \needlines{2}

--- a/QuickTour/QuickTour.tex
+++ b/QuickTour/QuickTour.tex
@@ -761,7 +761,7 @@ To make this example into something that the system can use, we turn it into a t
 \needlines{3}
 \begin{method}[testShout]{A test for a shout method}
 testShout
-	self assert: ('Don''t panic' shout = 'DON''T PANICBANG')
+	self assert: 'DON''T PANICBANG' equals: 'Don''t panic' shout.
 \end{method} % BANG is the escape for !
 
 How do we create a new method in \sq?   First, we have to decide which class the method should belong to.

--- a/SmalltalkSources/SBE-Environment.package/StringTest.extension/instance/testSuffixFound.st
+++ b/SmalltalkSources/SBE-Environment.package/StringTest.extension/instance/testSuffixFound.st
@@ -1,4 +1,4 @@
 *SBE-Environment
 testSuffixFound 
-	self assert: 'readme.txt' suffix = 'txt'.
-	self assert: 'read.me.txt' suffix = 'txt'
+	self assert: 'txt' equals: 'readme.txt' suffix.
+	self assert: 'txt' equals: 'read.me.txt' suffix.

--- a/SmalltalkSources/SBE-Environment.package/StringTest.extension/instance/testSuffixNotFound.st
+++ b/SmalltalkSources/SBE-Environment.package/StringTest.extension/instance/testSuffixNotFound.st
@@ -1,3 +1,3 @@
 *SBE-Environment
 testSuffixNotFound 
-	self assert: 'readme' suffix = ''
+	self assert: '' equals: 'readme' suffix.

--- a/SmalltalkSources/SBE-Environment.package/StringTest.extension/methodProperties.json
+++ b/SmalltalkSources/SBE-Environment.package/StringTest.extension/methodProperties.json
@@ -2,5 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testSuffixFound" : "ct 1/17/2020 15:09",
-		"testSuffixNotFound" : "on 5/7/2008 17:05" } }
+		"testSuffixFound" : "ct 9/22/2020 13:57",
+		"testSuffixNotFound" : "ct 9/22/2020 13:57" } }

--- a/SmalltalkSources/SBE-QuickTour.package/StringTest.extension/instance/testShout.st
+++ b/SmalltalkSources/SBE-QuickTour.package/StringTest.extension/instance/testShout.st
@@ -1,3 +1,3 @@
 *SBE-QuickTour
 testShout
-	self assert: ('Don''t panic' shout = 'DON''T PANIC!')
+	self assert: 'DON''T PANIC!' equals: 'Don''t panic' shout.

--- a/SmalltalkSources/SBE-QuickTour.package/StringTest.extension/methodProperties.json
+++ b/SmalltalkSources/SBE-QuickTour.package/StringTest.extension/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testShout" : "ct 12/6/2019 19:16" } }
+		"testShout" : "ct 9/22/2020 13:58" } }


### PR DESCRIPTION
See [https://github.com/codeZeilen/SqueakByExample-english/issues/21#issuecomment-695981273](https://github.com/codeZeilen/SqueakByExample-english/issues/21#issuecomment-695981273-permalink:~:text=%3A%41-,SUnit%20%2F%20Other%20Assertions%20explains%20%23deny%3A%2C%20%23assert%3Adescription%3A%2C%20%23should%3Araise%3A%20and%20so%20on.%20However%2C%20%23assert%3Aequals%3A%20seems%20to%20be%20explained%20at%20no%20point.%20So%20yes%2C%20custom%20assertions%20are%20explained%20later%2C%20so%20do%20you%20recommend%20to%20keep%20the%20old%20version%20with%20%23%3D%20in%20chapter%20Environments%3F,No%2C%20let's%20only%20show%20idiomatic%20code%20as%20often%20as%20possible%20as%20long%20it%20does%20not%20interfer%20with%20some%20flow%20of%20an%20explanation).